### PR TITLE
Add macros to derive Serialize and Deserialize

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -36,7 +36,7 @@
 ///     VariantA,
 ///     VariantB,
 /// }
-/// 
+///
 /// #[derive(Debug)]
 /// pub struct MyError(String);
 ///
@@ -96,6 +96,102 @@ macro_rules! forward_display_to_serde {
         impl ::std::fmt::Display for $type {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 write!(f, "{}", $crate::to_string(self).unwrap())
+            }
+        }
+    }
+}
+
+/// Derives `serde::Deserialize` a type that implements `FromStr`.
+///
+/// ```rust
+/// use std::str::FromStr;
+/// use std::num::ParseIntError;
+/// #[macro_use] extern crate serde;
+/// #[macro_use] extern crate serde_plain;
+/// # fn main() {
+///
+/// pub struct MyStruct(u32);
+///
+/// impl FromStr for MyStruct {
+///     type Err = ParseIntError;
+///     fn from_str(value: &str) -> Result<MyStruct, Self::Err> {
+///         Ok(MyStruct(value.parse()?))
+///     }
+/// }
+///
+/// derive_deserialize_from_str!(MyStruct, "valid positive number");
+/// # }
+/// ```
+///
+/// This automatically implements `fmt::Serialize` which will invoke the
+/// `from_str` function on the target type internally. First argument is
+/// the name of the type, the second is a message for the expectation
+/// error (human readable type effectively).
+#[macro_export]
+macro_rules! derive_deserialize_from_str {
+    ($type:ty, $expectation:expr) => {
+        impl<'de> ::serde::de::Deserialize<'de> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: ::serde::de::Deserializer<'de>,
+            {
+                struct V;
+
+                impl<'de> ::serde::de::Visitor<'de> for V {
+                    type Value = $type;
+
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        formatter.write_str($expectation)
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<$type, E>
+                    where
+                        E: ::serde::de::Error,
+                    {
+                        value
+                            .parse()
+                            .map_err(|_| ::serde::de::Error::invalid_value(
+                                ::serde::de::Unexpected::Str(value), &self))
+                    }
+                }
+
+                deserializer.deserialize_str(V)
+            }
+        }
+    }
+}
+
+/// Derives `serde::Serialize` a type that implements `fmt::Display`.
+///
+/// ```rust
+/// use std::fmt;
+/// #[macro_use] extern crate serde;
+/// #[macro_use] extern crate serde_plain;
+/// # fn main() {
+///
+/// pub struct MyStruct(u32);
+///
+/// impl fmt::Display for MyStruct {
+///     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+///         write!(f, "{}", self.0)
+///     }
+/// }
+///
+/// derive_serialize_from_display!(MyStruct);
+/// # }
+/// ```
+///
+/// This automatically implements `fmt::Serialize` which will invoke the
+/// `to_string` method on the target.
+#[macro_export]
+macro_rules! derive_serialize_from_display {
+    ($type:ty) => {
+        impl ::serde::ser::Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::ser::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
             }
         }
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,7 +47,7 @@ macro_rules! forward_from_str_to_serde {
     ($type:ty) => {
         impl ::std::str::FromStr for $type {
             type Err = $crate::Error;
-            fn from_str(s: &str) -> Result<$type, Self::Err> {
+            fn from_str(s: &str) -> ::std::result::Result<$type, Self::Err> {
                 $crate::from_str(s)
             }
         }
@@ -55,7 +55,7 @@ macro_rules! forward_from_str_to_serde {
     ($type:ty, |$var:ident| -> $err_type:ty { $err_conv:expr }) => {
         impl ::std::str::FromStr for $type {
             type Err = $err_type;
-            fn from_str(s: &str) -> Result<$type, Self::Err> {
+            fn from_str(s: &str) -> ::std::result::Result<$type, Self::Err> {
                 $crate::from_str(s).map_err(|$var| ($err_conv))
             }
         }
@@ -63,7 +63,7 @@ macro_rules! forward_from_str_to_serde {
     ($type:ty, $err_type:ty) => {
         impl ::std::str::FromStr for $type {
             type Err = $err_type;
-            fn from_str(s: &str) -> Result<$type, Self::Err> {
+            fn from_str(s: &str) -> ::std::result::Result<$type, Self::Err> {
                 $crate::from_str(s).map_err(|e| e.into())
             }
         }
@@ -131,7 +131,7 @@ macro_rules! forward_display_to_serde {
 macro_rules! derive_deserialize_from_str {
     ($type:ty, $expectation:expr) => {
         impl<'de> ::serde::de::Deserialize<'de> for $type {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
             where
                 D: ::serde::de::Deserializer<'de>,
             {
@@ -144,7 +144,7 @@ macro_rules! derive_deserialize_from_str {
                         formatter.write_str($expectation)
                     }
 
-                    fn visit_str<E>(self, value: &str) -> Result<$type, E>
+                    fn visit_str<E>(self, value: &str) -> ::std::result::Result<$type, E>
                     where
                         E: ::serde::de::Error,
                     {
@@ -187,7 +187,7 @@ macro_rules! derive_deserialize_from_str {
 macro_rules! derive_serialize_from_display {
     ($type:ty) => {
         impl ::serde::ser::Serialize for $type {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
             where
                 S: ::serde::ser::Serializer,
             {

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -1,3 +1,6 @@
+use std::{fmt, num, str};
+
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
@@ -34,6 +37,21 @@ pub enum Test3 {
 #[derive(Debug, PartialEq, Eq)]
 pub struct Test3Error(String);
 
+pub struct TestStruct(u32);
+
+impl str::FromStr for TestStruct {
+    type Err = num::ParseIntError;
+    fn from_str(value: &str) -> Result<TestStruct, Self::Err> {
+        Ok(TestStruct(value.parse()?))
+    }
+}
+
+impl fmt::Display for TestStruct {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 forward_from_str_to_serde!(Test);
 forward_display_to_serde!(Test);
 
@@ -43,18 +61,33 @@ forward_display_to_serde!(Test2);
 forward_from_str_to_serde!(Test3, |err| -> Test3Error { Test3Error(err.to_string()) });
 forward_display_to_serde!(Test3);
 
+derive_deserialize_from_str!(TestStruct, "valid positive number");
+derive_serialize_from_display!(TestStruct);
+
 #[test]
-fn test_basics() {
+fn test_forward_basics() {
     assert_eq!(Test::FooBarBaz.to_string(), "foo_bar_baz");
     assert_eq!("foo_bar_baz".parse::<Test>().unwrap(), Test::FooBarBaz);
 }
 
 #[test]
-fn test_custom_error() {
+fn test_forward_custom_error() {
     assert_eq!("whatever".parse::<Test2>(), Err(Test2Error));
 }
 
 #[test]
-fn test_custom_error_conversion() {
+fn test_forward_custom_error_conversion() {
     assert_eq!("whatever".parse::<Test3>(), Err(Test3Error("unknown variant `whatever`, expected `FooBarBaz` or `BlahBlah`".to_string())));
+}
+
+#[test]
+fn test_derive_deserialize() {
+    let test: TestStruct = serde_plain::from_str("42").unwrap();
+    assert_eq!(TestStruct(42).0, test.0);
+}
+
+#[test]
+fn test_derive_serialize() {
+    let test = serde_plain::to_string(&TestStruct(42)).unwrap();
+    assert_eq!("42", test.as_str());
 }


### PR DESCRIPTION
This PR introduces two new macros, `derive_deserialize_from_str` and `derive_serialize_from_display` and fixes references to `::std::result::Result` in all macros.

<img width="985" alt="screen shot 2018-03-19 at 16 40 46" src="https://user-images.githubusercontent.com/1433023/37605846-662349ce-2b94-11e8-9a27-353a51a372fa.png">
<img width="978" alt="screen shot 2018-03-19 at 16 40 55" src="https://user-images.githubusercontent.com/1433023/37605848-663e782a-2b94-11e8-977d-5b2fdff16821.png">
