### PR TITLE
Add support for untagged enums

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -40,11 +40,11 @@ macro_rules! forward_to_deserialize_from_str {
 impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de> {
     type Error = Error;
 
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Error>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
     where
         V: Visitor<'de>,
     {
-        Err(Error::ImpossibleDeserialization("any"))
+        self.deserialize_str(visitor)
     }
 
     forward_to_deserialize_from_str!(deserialize_bool, visit_bool, "boolean");


### PR DESCRIPTION
By forwarding deserialize_any to deserialize_str, certain types of untagged enums
can be supported.